### PR TITLE
Added stacking urls on contents.js

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,6 +2,21 @@
 //function addRow() {
 //...
 //}
+let address = window.location.href
 chrome.runtime.sendMessage(undefined,
-	{ url: window.location.href}  
+	{ url: address}  
 )
+chrome.storage.local.get(['url'], function(result) {	
+//[...result.url, address]
+	let arry = [];
+	if (result.url === '') {
+		arry = [address]
+	} else {
+		arry = [...result.url, address]
+	}
+	chrome.storage.local.set({url: arry }, function() {
+		console.log(result)
+	});
+
+});
+

--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
-
-chrome.runtime.sendMessage({
-  url: window.location.href,
-  addRow()
-})
-  
+//need addRow() here
+//function addRow() {
+//...
+//}
+chrome.runtime.sendMessage(undefined,
+	{ url: window.location.href}  
+)

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
+	    //popup.js is already added on popup.html
             "js": ["content.js", "popup.js"]
         }
         

--- a/popup.js
+++ b/popup.js
@@ -35,8 +35,8 @@ function Logger(isLogging) {
     }); 
 }         
           
-             
-addRow();
+//used addrow() under line 57 
+//addRow();
 console.log(addRow);
 
 //button to start/stop logging
@@ -51,6 +51,17 @@ chrome.storage.local.set({key: Logger()}, function() {
     console.log('value is set to  ' + Logger());
 });
 
+//defined url here to save address from local storage;
+let url = '';
+
+chrome.storage.local.get(['url'], function(result) {
+    console.log('url value currently is ' + result.url);
+    url = result.url[result.url.length - 1];
+	console.log('inner url',url);
+    //addRow() is used here
+	addRow();
+});
+
 chrome.storage.local.get(['key'], function(result) {
     console.log('value currently is ' + result.key);
 });
@@ -59,17 +70,17 @@ chrome.storage.local.get(['key'], function(result) {
 //function to append row to HTML table 
 function addRow() {
         //perhaps need an for loop for every page visited 
-  
-    
-    const bg = chrome.extension.getBackgroundPage()    
-    console.log(bg)
+      
+   // const bg = chrome.extension.getBackgroundPage()    
+   // console.log(bg)
     
     
     //Object.keys(bg.get).forEach(function (url) {
     
         
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-        let url = tabs[0].url;
+      //deleted url because it's already defined line 59
+	    // let url = tabs[0].url;
     //get html table
         // Append product to the table
     var table = document.getElementById("tbodyID");
@@ -114,7 +125,7 @@ function addRow() {
                     downloadsCell.innerHTML = downloads;
                   console.log("works");
      //})
-    }) 
+    })
             }
  
 


### PR DESCRIPTION
Hello, @brakiajackson. Am here to contribute after answering your stackoverflow post. There were two issues to add features for the extension after you [solved the problems](https://stackoverflow.com/questions/64951776/how-to-get-my-start-and-stop-button-to-work-using-javascript/64954029?noredirect=1#comment114852822_64954029) that buttons doesn't worked and current url isn't added. So now the two issues are that one is keeping saving logs on the extension and other is keeping state of the button in popup.html. This pull reqeust about the first one keeping saving logs. Currently saving logs are added but in your github page there is new for me, which download logs as .csv. So working csv would be later pull request. 

On this pull request saving urls are added. Whenever wep page is turned, current url is saved in `storage.local`. While edditing there was an error and it seems it will be working after deleting `popup.js` on `content_scripts` in `manifest.json`. Below is the reason why the list should be deleted. 

popup.js is script for popup.html. HTML file can't load browser extension js files like contents.js. That's why addRow() can't be loaded on content.js. 

Here below are detailed changes:
1. contents.js :
* address is defined for using url in `storage.local` function.
* in `storage.local` function urls are saved in storage(for loading urls on popup.js).
2. manifest.js : 
* popup.js in `content_scripts` isn't needed(it's added on popup.html already).
3. popup.js :
* `addRow()` in popup.js is moved into `storage.local`. The reason is below.
* `storage.local` is added for using saved urls. To use loaded from `storage.local.get` there is no option without moving `addRow()` into `storage.local` function. It's because the function in storage.local is executed after popup.js is executed. 
* getBackgroundPage() is commented. It's not need for now.
* defined url in addRow() is commented because url is defined on line 59.


